### PR TITLE
Support AT Protocol handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # markdown-it-handle · [![test](https://github.com/paulrobertlloyd/markdown-it-handle/actions/workflows/test.yml/badge.svg)](https://github.com/paulrobertlloyd/markdown-it-handle/actions/workflows/test.yml)
 
-Links to users across different social networks using [`markdown-it`](https://github.com/markdown-it/markdown-it) and the handle format `@username@host`.
+Link to users on social networks using [`markdown-it`](https://github.com/markdown-it/markdown-it) and the `@username@host` handle format used by networks that use ActivityPub, such as Mastodon.
+
+You can also link to users on social networks that use the [AT Protocol](https://atproto.com), such as Bluesky. In this instance, handles follow the `@username.host` format, where `host` is a personal data server (PDS).
 
 ## Requirements
 
@@ -20,6 +22,8 @@ const md = markdownit();
 
 md.use(handle);
 ```
+
+### ActivityPub
 
 This plugin converts the format used for username handles common to federated social networks, into linked usernames.
 
@@ -42,6 +46,26 @@ the following markup will be generated (lines wrapped for clarity):
 This can be particularly useful if you are syndicating plain-text posts using Markdown, but rendering them on your own site as HTML.
 
 Syndicated text containing handles will get parsed as mentions by the federated server, while readable link text is shown to readers on your own website.
+
+### AT Protocol
+
+This plugin converts the format used for username handles common to federated social networks, into linked usernames.
+
+For example, given this Markdown:
+
+```md
+@paulrobertlloyd.com but not @paulrobertlloyd.bsky.social.
+```
+
+the following markup will be generated:
+
+```html
+<p><a href="https://bsky.app/profile/paulrobertlloyd.com" rel="external">@paulrobertlloyd.com</a> but not <a href="https://bsky.app/profile/paulrobertlloyd.bsky.social" rel="external">@paulrobertlloyd.bsky.social</a>.</p>
+```
+
+Syndicated text containing handles can get parsed as mentions by an AT Protocol application, while readable link text is shown to readers on your own website.
+
+The default AT Protocol application is `bsky.app`, but you can override this behaviour value using the `atProto.app` option.
 
 ## Options
 
@@ -111,6 +135,31 @@ This will output:
 
 ```html
 <p><a href="https://flickr.com/people/username" rel="external">@username</a></p>
+```
+
+### AT Protocol AppView
+
+By default, AT Protocol handles link to profile pages on [bsky.app](https://bsky.app).
+
+You can change this value using the `atProto.app` option. You can also add a custom prefix if this application uses a different URL format for profile pages:
+
+```js
+md.use(handle, {
+  atProto: {
+    app: "example.app"
+  },
+  prefixes: {
+    "example.app": "users/",
+  },
+});
+
+marked("@username.bsky.social");
+```
+
+This will output:
+
+```html
+<p><a href="https://example.app/users/@username.bsky.social" rel="external">@username.bsky.social</a></p>
 ```
 
 ## Releasing new versions

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ export default function (md, pluginOptions = {}) {
       rel: "external",
     },
     prefixes,
+    atProto: {
+      app: "bsky.app",
+    },
   };
 
   // Merge options

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -1,4 +1,5 @@
 export const prefixes = {
+  "bsky.app": "profile/",
   "flickr.com": "photos/",
   "github.com": false,
   "instagram.com": false,

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -1,4 +1,4 @@
-const HANDLE_REGEXP = /@(?<user>[\w.%+-]+)@(?<host>[\w.-]+\.[a-z\d-]{2,})/gi;
+const HANDLE_REGEXP = /(@(?<user>[\w.%+-]+))?@(?<host>[\w.-]+\.[a-z\d-]{2,})/gi;
 
 /** @typedef {import('markdown-it/lib/rules_core/state_core.mjs').default} StateCore */
 /** @typedef {import('markdown-it/lib/token.mjs').default} Token */
@@ -65,9 +65,17 @@ export function replace(state, options) {
       let lastIndex = 0;
 
       while ((match = HANDLE_REGEXP.exec(content)) !== null) {
-        const { user, host } = match.groups;
+        let { user, host } = match.groups;
 
-        // Use prefixes defined in options
+        // AT Proto uses domain names as user names
+        // So we’ll make the username this domain name
+        // The host will be user’s chosen PDS (Personal Data Server)
+        if (!user) {
+          user = host;
+          host = options.atProto?.app;
+        }
+
+        // Get prefix to show before username in basepath
         let prefix;
         const { prefixes } = options;
         switch (prefixes[host]) {

--- a/test/fixtures/handle-custom-prefix.txt
+++ b/test/fixtures/handle-custom-prefix.txt
@@ -1,3 +1,19 @@
+Bluesky handle (`profile/username.bsky.social` prefix)
+.
+@username.bsky.social
+.
+<p><a href="https://bsky.app/profile/username.bsky.social" rel="external">@username.bsky.social</a></p>
+.
+
+
+Bluesky custom domain handle (`profile/example.website` prefix)
+.
+@example.website
+.
+<p><a href="https://bsky.app/profile/example.website" rel="external">@example.website</a></p>
+.
+
+
 Flickr handle (`photos/` prefix)
 .
 @username@flickr.com


### PR DESCRIPTION
Fixes #9.

The format the AT Protocol is different to that used by ActivityPub:

ActivityPub: `@username@host`
AT Protocol: `@username.host` where `host` is a Personal Data Server (PDS)

AT Protocol also has the concept of applications which can be (and most likely is) hosted on a different domain from that of a user’s PDS. To counter this, the `atProto.app` option is provided (defaulting to `bsky.app`).